### PR TITLE
Add Preact version-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Bindings for redux-bundler to Preact
 
 ## install
 
-Install the latest for a Preact-X compatible version:
+Install v2 for Preact >=10.0.0:
 
 ```
 npm install redux-bundler-preact
 ```
 
-For legacy Preact support (v3–8), install v1:
+Install v1 for Preact v3-8:
 
 ```
 npm install redux-bundler-preact@^1

--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ Bindings for redux-bundler to Preact
 
 ## install
 
+Install the latest for a Preact-X compatible version:
+
 ```
 npm install redux-bundler-preact
+```
+
+For legacy Preact support (v3–8), install v1:
+
+```
+npm install redux-bundler-preact@^1
 ```
 
 ## example / docs


### PR DESCRIPTION
* **Problem:** #2 added support for Preact X but didn't update the README
* **Solution:** Add installation instructions for Preact X and older Preact versions
* **Testing:** n/a